### PR TITLE
Changed PartitionedRetrySpecification to take in a routingConfigs instea...

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/RetryAndCallbackSpecs.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/RetryAndCallbackSpecs.scala
@@ -46,12 +46,6 @@ object RetrySpecifications {
  */
 class RetrySpecifications[ResponseMsg](val maxRetry: Int,
                                                   val callback: Option[Either[Throwable, ResponseMsg] => Unit]) {
-  //Validation checks go here:
-  /* removed because causing testing errors
-  if (maxRetry == 0 && callback != None) {
-    throw new IllegalArgumentException("maxRetry must be greater than 0 for callback options to work")
-  }
-*/
 
 }
 
@@ -62,8 +56,9 @@ object PartitionedRetrySpecifications {
   //can have maxRetry without callback, but you cannot have callback without maxRetry
   def apply[ResponseMsg](maxRetry: Int = 0,
                          callback: Option[Either[Throwable, ResponseMsg] => Unit] = None, //new FutureAdapterListener[ResponseMsg],
-                         retryStrategy: Option[RetryStrategy] = None) = {
-    new PartitionedRetrySpecifications[ResponseMsg](maxRetry, callback, retryStrategy)
+                         retryStrategy: Option[RetryStrategy] = None,
+                         routingConfigs: RoutingConfigs = RoutingConfigs.defaultRoutingConfigs) = {
+    new PartitionedRetrySpecifications[ResponseMsg](maxRetry, callback, retryStrategy, routingConfigs)
   }
 
 
@@ -82,14 +77,7 @@ object PartitionedRetrySpecifications {
 class PartitionedRetrySpecifications[ResponseMsg](maxRetry: Int,
                                          callback: Option[Either[Throwable, ResponseMsg] => Unit],
                                          var retryStrategy: Option[RetryStrategy],
-                                         var duplicatesOk: Boolean = false) extends RetrySpecifications[ResponseMsg](maxRetry, callback) {
-
-  val routingConfigs = new RoutingConfigs(retryStrategy != None, duplicatesOk)
-  def setConfig(config: NetworkClientConfig): Unit = {
-    duplicatesOk = config.duplicatesOk
-    if (retryStrategy != null)
-      retryStrategy = config.retryStrategy
-  }
+                                         var routingConfigs: RoutingConfigs = RoutingConfigs.defaultRoutingConfigs) extends RetrySpecifications[ResponseMsg](maxRetry, callback) {
 
 }
 

--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/PartitionedNetworkClient.scala
@@ -25,7 +25,7 @@ import server.{MessageExecutorComponent, NetworkServer}
 import netty.NettyPartitionedNetworkClient
 import client.{PartitionedNodeSpec, NetworkClientConfig}
 import cluster.{Node, ClusterDisconnectedException, InvalidClusterException, ClusterClientComponent}
-
+/*
 object RoutingConfigs {
   val defaultRoutingConfigs = new RoutingConfigs(false, false)
   def getDefaultRoutingConfigs():RoutingConfigs = {
@@ -37,7 +37,7 @@ class RoutingConfigs(SelectiveRetry: Boolean, DuplicatesOk: Boolean ) {
   val selectiveRetry = SelectiveRetry
   val duplicatesOk = DuplicatesOk
 }
-
+*/
 object PartitionedNetworkClient {
   def apply[PartitionedId](config: NetworkClientConfig, loadBalancerFactory: PartitionedLoadBalancerFactory[PartitionedId]): PartitionedNetworkClient[PartitionedId] = {
     val nc = new NettyPartitionedNetworkClient(config, loadBalancerFactory)
@@ -363,7 +363,7 @@ trait PartitionedNetworkClient[PartitionedId] extends BaseNetworkClient {
   {
     val requestSpec = PartitionedRequestSpecification[RequestMsg, PartitionedId](rb = Some(requestBuilder));
     val nodeSpec = new PartitionedNodeSpec[PartitionedId](ids).setCapability(capability).setPersistentCapability(persistentCapability).setClusterId(clusterId).setNumberOfReplicas(numberOfReplicas).build;
-    val retrySpec = PartitionedRetrySpecifications[ResponseMsg](maxRetry, retryStrategy = retryStrategy);
+    val retrySpec = PartitionedRetrySpecifications[ResponseMsg](maxRetry, retryStrategy = retryStrategy, routingConfigs = routingConfigs);
     sendRequest(requestSpec, nodeSpec, retrySpec)
 
     /*


### PR DESCRIPTION
...d of duplicatesOk. Also, commented out routingConfigs from partitionedNetworkClient, since they are now defined in the RetryAndCallback specifications.